### PR TITLE
some type stability enhancements

### DIFF
--- a/Julia/src/CacheFlow.jl
+++ b/Julia/src/CacheFlow.jl
@@ -7,7 +7,7 @@ using DataFrames, CSV, Memoize
 data_file(file) = joinpath(dirname(dirname(@__DIR__)), "Python", "BasicTerm_M", file)
 read_csv(file) = CSV.read(data_file(file), DataFrame)
 
-const final_timestep = Ref(240)
+const final_timestep = Ref{Int}(240)
 duration(t::Int) = t ÷ 12
 
 include("mortality.jl")
@@ -39,7 +39,7 @@ pv_pols_if() = foldl((res, t) -> (res .+= policies_inforce(t) .* disc_factor(t))
 pv_premiums() = foldl((res, t) -> (res .+= premiums(t) .* disc_factor(t)), 0:final_timestep[]; init = zeros(Float64, length(issue_age)))
 
 net_premium_pp() = pv_claims() ./ pv_pols_if()
-const cache_premiums_pp = Dict{Tuple{},Any}()
+const cache_premiums_pp = Dict{Tuple{},Vector{Float64}}()
 @memoize Returns(cache_premiums_pp)() premium_pp() = round.((1 .+ loading_prem) .* net_premium_pp(); digits = 2)
 premiums(t::Int) = premium_pp() .* policies_inforce(t)
 pv_net_cf() = pv_premiums() .- pv_claims() .- pv_expenses() .- pv_commissions()

--- a/Julia/src/mortality.jl
+++ b/Julia/src/mortality.jl
@@ -12,12 +12,12 @@ get_monthly_rate(table::BasicMortality, t::Int) = 1 .- (1 .- get_annual_rate(tab
 
 const basic_mortality = BasicMortality()
 
-const cache_monthly_basic_mortality = Dict{Tuple{Int},Any}()
+const cache_monthly_basic_mortality = Dict{Tuple{Int},Vector{Float64}}()
 @memoize Returns(cache_monthly_basic_mortality)() monthly_basic_mortality(t) = get_monthly_rate(basic_mortality, t)
 policies_death(t) = policies_inforce(t) .* monthly_basic_mortality(t)
 
-const cache_policies_inforce = Dict{Tuple{Int64},Any}()
-@memoize Returns(cache_policies_inforce)() function policies_inforce(t)
+const cache_policies_inforce = Dict{Tuple{Int64},Vector{Float64}}()
+@memoize Returns(cache_policies_inforce)() function policies_inforce(t)::Vector{Float64}
   t == 0 && return ones(length(issue_age))
   policies_inforce(t - 1) .- policies_lapse(t - 1) .- policies_death(t - 1) .- policies_maturity(t)
 end
@@ -26,6 +26,6 @@ lapse_rate(t) = max(0.1 - 0.02 * duration(t), 0.02)
 
 policies_term() = model_points[:, :policy_term]
 
-function policies_maturity(t)
+function policies_maturity(t)::Vector{Float64}
   (t .== 12 .* policies_term()) .* (policies_inforce(t - 1) .- policies_lapse(t - 1) .- policies_death(t - 1))
 end


### PR DESCRIPTION
This makes the Julia version ~15% faster than before by avoiding `Any` and providing some hints to the return types (theory: memoization/recursion made the types hard to infer?)