### PR TITLE
start julia not single-threaded

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           version: '1.9.3'
       - name: Benchmark
-        run: julia --project -e 'using Pkg; Pkg.instantiate(); include("main.jl")'
+        run: julia --threads=auto --project -e 'using Pkg; Pkg.instantiate(); include("main.jl")'
       - run: ls
       - name: upload Julia benchmark
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
If not set via environment variable, need to pass argument to have Julia start with threads enabled